### PR TITLE
pep517 support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["cython", "numpy", "setuptools"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ else:
 
 setup(
     name='uavro',
-    version='0.1.2',
+    version='0.1.3',
     description='Cython-optimized reader for tabular Avro data',
     author='Martin Durant',
     author_email='mdurant@continuum.io',

--- a/uavro/__init__.py
+++ b/uavro/__init__.py
@@ -1,3 +1,3 @@
 from .core import read, dask_read_avro
 
-__version__ = '0.1.2'
+__version__ = '0.1.3'


### PR DESCRIPTION
Some pip installs are failing for uavro because of a lack of pep517 support.  Simple solution to support pep517.
Prior case failed on command:
`pip wheel --use-pep517 "uavro==0.1.2"`


Tested manually via:
`python setup.py sdist`
`pip wheel --use-pep517 "dist/uavro-0.1.2.tar.gz"`

Reference: https://github.com/conda-forge/uavro-feedstock/pull/10
@martindurant should I bump version to 0.1.3 in this PR?
